### PR TITLE
Add basic sharding support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN yarn build
 
 # Production Step -- Run our compiled TypeScript code
 FROM node:alpine AS production
+LABEL org.opencontainers.image.source="https://github.com/Sn0wCrack/saucybot-discord"
 
 WORKDIR /bot
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN yarn build
 
 # Production Step -- Run our compiled TypeScript code
 FROM node:alpine AS production
+
 LABEL org.opencontainers.image.source="https://github.com/Sn0wCrack/saucybot-discord"
+LABEL org.opencontainers.image.authors="Sn0wCrack"
 
 WORKDIR /bot
 ENV NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you would like to add this bot to your server [click here](https://discordapp
 
 * Currently Supports:
   * ArtStation - Embeds up to X extra images (X is configurable, default 5)
-  * Twitter Videos - Embeds a twitter video
+  * Twitter Videos - Embeds a Twitter videoes and GIFs
     * NOTE: On the live version this is temporary until discord fixes video embeds from Twitter, may not always work as expected due to API rate limits
   * Hentai Foundry - Creates embed as none exists for site.
   * Pixiv - Posts up to X images of the set (X is configurable, default 5)

--- a/nodemon.json
+++ b/nodemon.json
@@ -2,5 +2,5 @@
     "watch": ["src"],
     "ext": ".ts,.js",
     "ignore": [],
-    "exec": "ts-node ./src/index.ts"
+    "exec": "ts-node ./src/bot.ts"
 }

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -4,31 +4,35 @@ import chalk from 'chalk';
 import { DateTime } from 'luxon';
 
 class Logger {
-    static fatal(message: any): void {
-        console.error(this.format(message, LogLevel.FATAL));
+    static fatal(message: any, source: string | number = ''): void {
+        console.error(this.format(message, LogLevel.FATAL, source));
     }
 
-    static error(message: any): void {
-        console.error(this.format(message, LogLevel.ERROR));
+    static error(message: any, source: string | number = ''): void {
+        console.error(this.format(message, LogLevel.ERROR, source));
     }
 
-    static warn(message: any): void {
-        console.warn(this.format(message, LogLevel.WARN));
+    static warn(message: any, source: string | number = ''): void {
+        console.warn(this.format(message, LogLevel.WARN, source));
     }
 
-    static info(message: any): void {
-        console.info(this.format(message, LogLevel.INFO));
+    static info(message: any, source: string | number = ''): void {
+        console.info(this.format(message, LogLevel.INFO, source));
     }
 
-    static debug(message: any): void {
-        console.debug(this.format(message, LogLevel.DEBUG));
+    static debug(message: any, source: string | number = ''): void {
+        console.debug(this.format(message, LogLevel.DEBUG, source));
     }
 
-    static trace(message: any): void {
-        console.debug(this.format(message, LogLevel.TRACE));
+    static trace(message: any, source: string | number = ''): void {
+        console.debug(this.format(message, LogLevel.TRACE, source));
     }
 
-    private static format(message: any, level: LogLevel): string {
+    private static format(
+        message: any,
+        level: LogLevel,
+        source: string | number = ''
+    ): string {
         const now = DateTime.local();
         const time = now.toFormat('yyyy-MM-dd HH:mm:ss');
 
@@ -41,7 +45,15 @@ class Logger {
             trace: chalk.green,
         }[level];
 
-        return color(`[${time}] [${level.toUpperCase()}] ${message}`);
+        let formatted = `[${time}]`;
+
+        if (source) {
+            formatted += ` [${source}]`;
+        }
+
+        formatted += ` [${level.toUpperCase()}] ${message}`;
+
+        return color(formatted);
     }
 }
 

--- a/src/MessageSender.ts
+++ b/src/MessageSender.ts
@@ -35,7 +35,10 @@ class MessageSender {
                 // TODO: When discord.js releases version 13, change this to be an inline-reply that doesn't ping
                 await recieved.channel.send(message);
             } catch (ex) {
-                Logger.error(ex.message);
+                Logger.error(
+                    ex.message,
+                    `Shard ${recieved.client.shard?.ids?.[0] ?? 0}`
+                );
             }
         }
 

--- a/src/SiteRunner.ts
+++ b/src/SiteRunner.ts
@@ -3,8 +3,6 @@ import BaseSite from './sites/BaseSite';
 import Sites from './sites';
 import { Message } from 'discord.js';
 import Environment from './Environment';
-import Logger from './Logger';
-
 class SiteRunner {
     sites: Array<BaseSite>;
 
@@ -24,10 +22,6 @@ class SiteRunner {
             if (!match) {
                 continue;
             }
-
-            Logger.info(
-                `${message.guild.name} - Matched message "${message.content}" to site ${site.identifier}`
-            );
 
             return Promise.resolve({
                 site: site,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,0 +1,92 @@
+import discord from 'discord.js';
+import dotenv from 'dotenv';
+import Environment from './Environment';
+import Logger from './Logger';
+import MessageSender from './MessageSender';
+import SiteRunner from './SiteRunner';
+
+dotenv.config();
+
+const client = new discord.Client();
+
+const runner = new SiteRunner();
+
+const sender = new MessageSender();
+
+const identifier = `Shard ${client.shard?.ids?.[0] ?? 0}`;
+
+client.on('message', async (message) => {
+    // If message is from Bot, then ignore it.
+    if (message.author == client.user) {
+        return;
+    }
+
+    // If the message is sorrounded by < > it'll be ignored.
+    if (message.content.match(/(<|\|\|)(?!@|#|:|a:).*(>|\|\|)/)) {
+        return;
+    }
+
+    try {
+        const response = await runner.process(message);
+
+        // If the response is false, then we didn't find anything.
+        if (response === false) {
+            return;
+        }
+
+        Logger.info(
+            `Matched message "${response.match[0]}" to site ${response.site.identifier}`,
+            identifier
+        );
+
+        // TODO: When discord.js releases version 13, change this to be an inline-reply that doesn't ping
+        const waitMessage = await message.reply(
+            `Matched link to ${response.site.identifier}, please wait...`
+        );
+
+        const processed = await response.site.process(response.match);
+
+        // If we failed to process the image, remove the wait message and return
+        if (processed === false) {
+            waitMessage.delete();
+            return;
+        }
+
+        await sender.send(message, processed);
+
+        await waitMessage.delete();
+    } catch (ex) {
+        Logger.error(ex.message, identifier);
+    }
+});
+
+// Capture any unhandled client errors here
+client.on('error', async (error) => {
+    Logger.error(error, identifier);
+});
+
+client.on('ready', async () => {
+    Logger.info('Ready', identifier);
+
+    client.setInterval(async () => {
+        let guilds = 0;
+
+        if (client.shard !== null) {
+            const results = await client.shard.fetchClientValues(
+                'guilds.cache.size'
+            );
+
+            guilds = results.reduce((acc, guildCount) => acc + guildCount, 0);
+        } else {
+            guilds = client.guilds.cache.size;
+        }
+
+        await client.user.setActivity(`Your Links... | Servers: ${guilds}`, {
+            type: 'WATCHING',
+        });
+    }, 5000);
+});
+
+client.login(Environment.get('DISCORD_API_KEY') as string).catch((err) => {
+    Logger.error(err.message, identifier);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,76 +1,17 @@
-import discord from 'discord.js';
+import { ShardingManager } from 'discord.js';
 import dotenv from 'dotenv';
+import { join } from 'path';
 import Environment from './Environment';
 import Logger from './Logger';
-import MessageSender from './MessageSender';
-import SiteRunner from './SiteRunner';
 
 dotenv.config();
 
-const client = new discord.Client();
-
-const runner = new SiteRunner();
-
-const sender = new MessageSender();
-
-client.on('message', async (message) => {
-    // If message is from Bot, then ignore it.
-    if (message.author == client.user) {
-        return;
-    }
-
-    // If the message is sorrounded by < > it'll be ignored.
-    if (message.content.match(/(<|\|\|)(?!@|#|:|a:).*(>|\|\|)/)) {
-        return;
-    }
-
-    try {
-        const response = await runner.process(message);
-
-        // If the response is false, then we didn't find anything.
-        if (response === false) {
-            return;
-        }
-
-        // TODO: When discord.js releases version 13, change this to be an inline-reply that doesn't ping
-        const waitMessage = await message.reply(
-            `Matched link to ${response.site.identifier}, please wait...`
-        );
-
-        const processed = await response.site.process(response.match);
-
-        // If we failed to process the image, remove the wait message and return
-        if (processed === false) {
-            waitMessage.delete();
-            return;
-        }
-
-        await sender.send(message, processed);
-
-        await waitMessage.delete();
-    } catch (ex) {
-        Logger.error(ex.message);
-    }
+const manager = new ShardingManager(join(__dirname, 'bot.js'), {
+    totalShards: 'auto',
+    token: Environment.get('DISCORD_API_KEY') as string,
 });
 
-// Capture any unhandled client errors here
-client.on('error', async (error) => {
-    Logger.error(error);
-});
-
-client.on('ready', async () => {
-    Logger.info('Ready');
-
-    client.setInterval(async () => {
-        await client.user.setActivity(
-            `Your Links... | Servers: ${client.guilds.cache.size}`,
-            {
-                type: 'WATCHING',
-            }
-        );
-    }, 5000);
-});
-
-client.login(Environment.get('DISCORD_API_KEY') as string).catch((err) => {
-    Logger.error(err.message);
-});
+manager.on('shardCreate', (shard) =>
+    Logger.info(`Launched Shard ${shard.id}`, 'Manager')
+);
+manager.spawn();

--- a/src/sites/TwitterVideo.ts
+++ b/src/sites/TwitterVideo.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import got from 'got';
 
 class TwitterVideo extends BaseSite {
-    identifier = 'TwitterVideo';
+    identifier = 'Twitter Video';
 
     pattern =
         /https?:\/\/(www\.)?twitter\.com\/(?<user>.*)\/status\/(?<id>\S+)(\?\=.*)?/i;

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,19 +219,19 @@
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/ws@^7.2.7":
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.4.tgz#93e1e00824c1de2608c30e6de4303ab3b4c0c9bc"
-  integrity sha512-d/7W23JAXPodQNbOZNXvl2K+bqAQrCMwlh/nuQsPSQk6Fq0opHoPrUw43aHsvSbIiQPr8Of2hkFbnz1XBFVyZQ==
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.5.tgz#8ff0f7efcd8fea19f51f9dd66cb8b498d172a752"
+  integrity sha512-8mbDgtc8xpxDDem5Gwj76stBDJX35KQ3YBoayxlqUQcL5BZUthiqP/VQ4PQnLHqM4PmlbyO74t98eJpURO+gPA==
   dependencies:
     "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.1.tgz#b9c7313321cb837e2bf8bebe7acc2220659e67d3"
-  integrity sha512-aoIusj/8CR+xDWmZxARivZjbMBQTT9dImUtdZ8tVCVRXgBUuuZyM5Of5A9D9arQPxbi/0rlJLcuArclz/rCMJw==
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.27.0.tgz#0b7fc974e8bc9b2b5eb98ed51427b0be529b4ad0"
+  integrity sha512-DsLqxeUfLVNp3AO7PC3JyaddmEHTtI9qTSAs+RB6ja27QvIM0TA8Cizn1qcS6vOu+WDLFJzkwkgweiyFhssDdQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.26.1"
-    "@typescript-eslint/scope-manager" "4.26.1"
+    "@typescript-eslint/experimental-utils" "4.27.0"
+    "@typescript-eslint/scope-manager" "4.27.0"
     debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
     lodash "^4.17.21"
@@ -239,60 +239,60 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.1.tgz#a35980a2390da9232aa206b27f620eab66e94142"
-  integrity sha512-sQHBugRhrXzRCs9PaGg6rowie4i8s/iD/DpTB+EXte8OMDfdCG5TvO73XlO9Wc/zi0uyN4qOmX9hIjQEyhnbmQ==
+"@typescript-eslint/experimental-utils@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.27.0.tgz#78192a616472d199f084eab8f10f962c0757cd1c"
+  integrity sha512-n5NlbnmzT2MXlyT+Y0Jf0gsmAQzCnQSWXKy4RGSXVStjDvS5we9IWbh7qRVKdGcxT0WYlgcCYUK/HRg7xFhvjQ==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.26.1"
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/typescript-estree" "4.26.1"
+    "@typescript-eslint/scope-manager" "4.27.0"
+    "@typescript-eslint/types" "4.27.0"
+    "@typescript-eslint/typescript-estree" "4.27.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.26.1.tgz#cecfdd5eb7a5c13aabce1c1cfd7fbafb5a0f1e8e"
-  integrity sha512-q7F3zSo/nU6YJpPJvQveVlIIzx9/wu75lr6oDbDzoeIRWxpoc/HQ43G4rmMoCc5my/3uSj2VEpg/D83LYZF5HQ==
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.27.0.tgz#85447e573364bce4c46c7f64abaa4985aadf5a94"
+  integrity sha512-XpbxL+M+gClmJcJ5kHnUpBGmlGdgNvy6cehgR6ufyxkEJMGP25tZKCaKyC0W/JVpuhU3VU1RBn7SYUPKSMqQvQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.26.1"
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/typescript-estree" "4.26.1"
+    "@typescript-eslint/scope-manager" "4.27.0"
+    "@typescript-eslint/types" "4.27.0"
+    "@typescript-eslint/typescript-estree" "4.27.0"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.26.1.tgz#075a74a15ff33ee3a7ed33e5fce16ee86689f662"
-  integrity sha512-TW1X2p62FQ8Rlne+WEShyd7ac2LA6o27S9i131W4NwDSfyeVlQWhw8ylldNNS8JG6oJB9Ha9Xyc+IUcqipvheQ==
+"@typescript-eslint/scope-manager@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.27.0.tgz#b0b1de2b35aaf7f532e89c8e81d0fa298cae327d"
+  integrity sha512-DY73jK6SEH6UDdzc6maF19AHQJBFVRf6fgAXHPXCGEmpqD4vYgPEzqpFz1lf/daSbOcMpPPj9tyXXDPW2XReAw==
   dependencies:
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/visitor-keys" "4.26.1"
+    "@typescript-eslint/types" "4.27.0"
+    "@typescript-eslint/visitor-keys" "4.27.0"
 
-"@typescript-eslint/types@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.26.1.tgz#9e7c523f73c34b04a765e4167ca5650436ef1d38"
-  integrity sha512-STyMPxR3cS+LaNvS8yK15rb8Y0iL0tFXq0uyl6gY45glyI7w0CsyqyEXl/Fa0JlQy+pVANeK3sbwPneCbWE7yg==
+"@typescript-eslint/types@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.27.0.tgz#712b408519ed699baff69086bc59cd2fc13df8d8"
+  integrity sha512-I4ps3SCPFCKclRcvnsVA/7sWzh7naaM/b4pBO2hVxnM3wrU51Lveybdw5WoIktU/V4KfXrTt94V9b065b/0+wA==
 
-"@typescript-eslint/typescript-estree@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.1.tgz#b2ce2e789233d62283fae2c16baabd4f1dbc9633"
-  integrity sha512-l3ZXob+h0NQzz80lBGaykdScYaiEbFqznEs99uwzm8fPHhDjwaBFfQkjUC/slw6Sm7npFL8qrGEAMxcfBsBJUg==
+"@typescript-eslint/typescript-estree@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.27.0.tgz#189a7b9f1d0717d5cccdcc17247692dedf7a09da"
+  integrity sha512-KH03GUsUj41sRLLEy2JHstnezgpS5VNhrJouRdmh6yNdQ+yl8w5LrSwBkExM+jWwCJa7Ct2c8yl8NdtNRyQO6g==
   dependencies:
-    "@typescript-eslint/types" "4.26.1"
-    "@typescript-eslint/visitor-keys" "4.26.1"
+    "@typescript-eslint/types" "4.27.0"
+    "@typescript-eslint/visitor-keys" "4.27.0"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.26.1":
-  version "4.26.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.1.tgz#0d55ea735cb0d8903b198017d6d4f518fdaac546"
-  integrity sha512-IGouNSSd+6x/fHtYRyLOM6/C+QxMDzWlDtN41ea+flWuSF9g02iqcIlX8wM53JkfljoIjP0U+yp7SiTS1onEkw==
+"@typescript-eslint/visitor-keys@4.27.0":
+  version "4.27.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.27.0.tgz#f56138b993ec822793e7ebcfac6ffdce0a60cb81"
+  integrity sha512-es0GRYNZp0ieckZ938cEANfEhsfHrzuLrePukLKtY3/KPXcq1Xd555Mno9/GOgXhKzn0QfkDLVgqWO3dGY80bg==
   dependencies:
-    "@typescript-eslint/types" "4.26.1"
+    "@typescript-eslint/types" "4.27.0"
     eslint-visitor-keys "^2.0.0"
 
 abbrev@1:
@@ -378,7 +378,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-anymatch@~3.1.1:
+anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
   integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
@@ -571,19 +571,19 @@ cheerio@^1.0.0-rc.3, cheerio@^1.0.0-rc.5:
     tslib "^2.2.0"
 
 chokidar@^3.2.2:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
-  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
   dependencies:
-    anymatch "~3.1.1"
+    anymatch "~3.1.2"
     braces "~3.0.2"
-    glob-parent "~5.1.0"
+    glob-parent "~5.1.2"
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.5.0"
+    readdirp "~3.6.0"
   optionalDependencies:
-    fsevents "~2.3.1"
+    fsevents "~2.3.2"
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1137,7 +1137,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@~2.3.1:
+fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -1161,7 +1161,7 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.0:
+glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1195,9 +1195,9 @@ globals@^13.6.0, globals@^13.9.0:
     type-fest "^0.20.2"
 
 globby@^11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
-  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -1879,17 +1879,17 @@ readable-stream@^3.1.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readdirp@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
-  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
 
 regexpp@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
-  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 registry-auth-token@^4.0.0:
   version "4.2.1"
@@ -2220,9 +2220,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript@^4.1.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
+  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
 undefsafe@^2.0.3:
   version "2.0.3"
@@ -2289,9 +2289,9 @@ url-parse-lax@^3.0.0:
     prepend-http "^2.0.0"
 
 user-agents@^1.0.559:
-  version "1.0.682"
-  resolved "https://registry.yarnpkg.com/user-agents/-/user-agents-1.0.682.tgz#a29281d4f8cb89b84bd790458364ad9069bcbbb9"
-  integrity sha512-fZ+OlnUp14Py1WknR81cLh4tEQyQL1bFiVuGs5XXaz+UUrYwR5r0gbHm41yi+czZfCRGaH2n+zS3kdt6WHPYOQ==
+  version "1.0.687"
+  resolved "https://registry.yarnpkg.com/user-agents/-/user-agents-1.0.687.tgz#389af13b598685687fd885174e42ffa3b57dfb18"
+  integrity sha512-vG5xTkHhlL3Ey46AX+Oy7sDRuJJtUfZ2T2VvkQmKyxvo2H3E1HBy7pp5ENslIsrGKs2/ZxQFbwEMC0A7mK6pyQ==
   dependencies:
     dot-json "^1.2.2"
     lodash.clonedeep "^4.5.0"
@@ -2348,9 +2348,9 @@ write-file-atomic@^3.0.0:
     typedarray-to-buffer "^3.1.5"
 
 ws@^7.4.4:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.0.tgz#0033bafea031fb9df041b2026fc72a571ca44691"
+  integrity sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This pull request adds in basic Sharding support via Discord.js' Sharding Manager

Sharding isn't needed right now but it was simple to add and has little overhead

Development still works via executing bot.ts directly, with our logger just assuming its on the first shard if no sharding is currently running.

The docker container and built version should be running index.js which will spawn the code from bot.js as needed.