### PR TITLE
Additional Caching via Redis to prevent API call rate limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,6 @@ services:
         env_file:
             - .env
         restart: unless-stopped
+    cache:
+        image: "redis:alpine"
+        restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "luxon": "^2.2.0",
         "picocolors": "^1.0.0",
         "pixiv-web-api": "^0.1.5",
+        "redis": "^4.0.3",
         "rimraf": "^3.0.2",
         "tough-cookie": "^4.0.0",
         "twitter-api-client": "^1.5.2"

--- a/src/CacheManager.ts
+++ b/src/CacheManager.ts
@@ -1,0 +1,45 @@
+import * as Redis from 'redis';
+import Environment from './Environment';
+
+class CacheManager {
+    private static instance: CacheManager;
+
+    private client;
+
+    private constructor() {
+        this.client = Redis.createClient({
+            url: Environment.get('REDIS_URL') as string,
+            username: Environment.get('REDIS_USERNAME') as string,
+            password: Environment.get('REDIS_PASSWORD') as string,
+            name: Environment.get('REDIS_NAME') as string,
+            database: Environment.get('REDIS_DATABASE', 0) as number,
+        });
+    }
+
+    public static async getInstance(): Promise<CacheManager> {
+        if (!CacheManager.instance) {
+            CacheManager.instance = new CacheManager();
+            await CacheManager.instance.connect();
+        }
+
+        return Promise.resolve(CacheManager.instance);
+    }
+
+    public async connect() {
+        return this.client.connect();
+    }
+
+    public has(key: string) {
+        return this.client.exists(key);
+    }
+
+    public get(key: string) {
+        return this.client.get(key);
+    }
+
+    public set(key: string, value: string, expireIn = 86400) {
+        return this.client.setEx(key, expireIn, value);
+    }
+}
+
+export default CacheManager;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -82,7 +82,7 @@ client.on('messageCreate', async (message) => {
                         // If we failed to process the image, remove the wait message and return
                         if (processed === false) {
                             waitMessage.delete();
-                            return;
+                            return resolve();
                         }
 
                         await sender.send(message, processed);
@@ -144,9 +144,9 @@ client.on('interactionCreate', async (interaction) => {
 
                     const processed = await response.site.process(match, null);
 
-                    if (!processed) {
+                    if (processed === false) {
                         interaction.editReply('Provided URL cannot be sauced');
-                        return;
+                        return resolve();
                     }
 
                     await sender.send(interaction, processed);

--- a/src/sites/Twitter.ts
+++ b/src/sites/Twitter.ts
@@ -38,7 +38,7 @@ class TwitterVideo extends BaseSite {
         match: RegExpMatchArray,
         source: Message | null
     ): Promise<ProcessResponse | false> {
-        const tweet = await this.getTweet(match);
+        const tweet = await this.getTweet(match.groups?.id);
 
         const hasVideo = tweet?.extended_entities?.media.find((item) =>
             ['video', 'animated_gif'].includes(item.type)
@@ -73,13 +73,13 @@ class TwitterVideo extends BaseSite {
             : this.handleRegular(tweet, match[0]);
     }
 
-    async getTweet(match: RegExpMatchArray): Promise<StatusesShow> {
-        const cacheKey = `twitter_tweet_${match.groups.id}`;
+    async getTweet(id: string): Promise<StatusesShow> {
+        const cacheKey = `twitter.tweet_${id}`;
         const cacheManager = await CacheManager.getInstance();
 
         const cachedValue = await cacheManager.remember(cacheKey, async () => {
             const results = await this.api.tweets.statusesShow({
-                id: match.groups.id,
+                id: id,
                 include_entities: true,
                 trim_user: false,
                 tweet_mode: 'extended',

--- a/src/sites/Twitter.ts
+++ b/src/sites/Twitter.ts
@@ -10,7 +10,6 @@ import { URL } from 'url';
 import { DateTime } from 'luxon';
 import { delay } from '../Helpers';
 import CacheManager from '../CacheManager';
-import Logger from '../Logger';
 
 class TwitterVideo extends BaseSite {
     identifier = 'Twitter';
@@ -78,7 +77,9 @@ class TwitterVideo extends BaseSite {
         const cacheKey = `twitter_tweet_${match.groups.id}`;
         const cacheManager = await CacheManager.getInstance();
 
-        if (await cacheManager.has(cacheKey)) {
+        const exists = await cacheManager.has(cacheKey);
+
+        if (exists === 1) {
             const cachedValue = await cacheManager.get(cacheKey);
             return JSON.parse(cachedValue) as StatusesShow;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,41 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@node-redis/bloom@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@node-redis/bloom/-/bloom-1.0.1.tgz#144474a0b7dc4a4b91badea2cfa9538ce0a1854e"
+  integrity sha512-mXEBvEIgF4tUzdIN89LiYsbi6//EdpFA7L8M+DHCvePXg+bfHWi+ct5VI6nHUFQE5+ohm/9wmgihCH3HSkeKsw==
+
+"@node-redis/client@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@node-redis/client/-/client-1.0.3.tgz#ece282b7ee07283d744e6ab1fa72f2d47641402c"
+  integrity sha512-IXNgOG99PHGL3NxN3/e8J8MuX+H08I+OMNmheGmZBXngE0IntaCQwwrd7NzmiHA+zH3SKHiJ+6k3P7t7XYknMw==
+  dependencies:
+    cluster-key-slot "1.1.0"
+    generic-pool "3.8.2"
+    redis-parser "3.0.0"
+    yallist "4.0.0"
+
+"@node-redis/graph@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@node-redis/graph/-/graph-1.0.0.tgz#baf8eaac4a400f86ea04d65ec3d65715fd7951ab"
+  integrity sha512-mRSo8jEGC0cf+Rm7q8mWMKKKqkn6EAnA9IA2S3JvUv/gaWW/73vil7GLNwion2ihTptAm05I9LkepzfIXUKX5g==
+
+"@node-redis/json@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@node-redis/json/-/json-1.0.2.tgz#8ad2d0f026698dc1a4238cc3d1eb099a3bee5ab8"
+  integrity sha512-qVRgn8WfG46QQ08CghSbY4VhHFgaTY71WjpwRBGEuqGPfWwfRcIf3OqSpR7Q/45X+v3xd8mvYjywqh0wqJ8T+g==
+
+"@node-redis/search@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@node-redis/search/-/search-1.0.2.tgz#8cfc91006ea787df801d41410283e1f59027f818"
+  integrity sha512-gWhEeji+kTAvzZeguUNJdMSZNH2c5dv3Bci8Nn2f7VGuf6IvvwuZDSBOuOlirLVgayVuWzAG7EhwaZWK1VDnWQ==
+
+"@node-redis/time-series@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@node-redis/time-series/-/time-series-1.0.1.tgz#703149f8fa4f6fff377c61a0873911e7c1ba5cc3"
+  integrity sha512-+nTn6EewVj3GlUXPuD3dgheWqo219jTxlo6R+pg24OeVvFHx9aFGGiyOgj3vBPhWUdRZ0xMcujXV5ki4fbLyMw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -665,6 +700,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+cluster-key-slot@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -1170,6 +1210,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+generic-pool@3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.8.2.tgz#aab4f280adb522fdfbdc5e5b64d718d3683f04e9"
+  integrity sha512-nGToKy6p3PAbYQ7p1UlWl6vSPwfwU6TMSWK7TTu+WUY4ZjyZQGniGGt2oNVvyNSpyZYSB43zMXVLcBm08MTMkg==
 
 get-stream@^4.1.0:
   version "4.1.0"
@@ -1913,6 +1958,30 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redis-errors@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
+redis@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.0.3.tgz#f60931175de6f5b5727240a08e58a9ed5cf0f9de"
+  integrity sha512-SJMRXvgiQUYN0HaWwWv002J5ZgkhYXOlbLomzcrL3kP42yRNZ8Jx5nvLYhVpgmf10xcDpanFOxxJkphu2eyIFQ==
+  dependencies:
+    "@node-redis/bloom" "1.0.1"
+    "@node-redis/client" "1.0.3"
+    "@node-redis/graph" "1.0.0"
+    "@node-redis/json" "1.0.2"
+    "@node-redis/search" "1.0.2"
+    "@node-redis/time-series" "1.0.1"
+
 regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -2338,7 +2407,7 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
-yallist@^4.0.0:
+yallist@4.0.0, yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
Adds support for caching using Redis, if it fails to connect to Redis it should fall back to not using cache and fetch everything manually.

Currently, only Twitter and Pixiv will be cached as they're the most popular.

The default cache timeout is 1 day.