### PR TITLE
fix: broken twitter embeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sn0wcrack/saucybot",
-    "version": "1.7.27",
+    "version": "1.7.28",
     "description": "A discord bot that fills in the gaps ",
     "repository": {},
     "author": "Sn0wCrack",

--- a/src/sites/Twitter.ts
+++ b/src/sites/Twitter.ts
@@ -53,10 +53,11 @@ class Twitter extends BaseSite {
             source = await source.fetch(true);
 
             hasTwitterEmbed = source.embeds?.find((item) => {
-                return (
+                const isFromTwitter =
                     item.url.includes('twitter.com') ||
-                    item.url.includes('t.co')
-                );
+                    item.url.includes('t.co');
+
+                return isFromTwitter && item.author !== null;
             });
         }
 


### PR DESCRIPTION
For reasons not entirely known Discord decided to break Twitter embeds even further by randomly not putting any useful tweet data into their embeds.

Resolves #25.