### PR TITLE
Use high resolution image links for twitter embeds

### DIFF
--- a/SaucyBot/Site/FxTwitter.cs
+++ b/SaucyBot/Site/FxTwitter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Web;
 using Discord;
 using Discord.WebSocket;
 using SaucyBot.Extensions;
@@ -291,7 +292,24 @@ public sealed class FxTwitter : BaseSite
             Path.GetFileName(parsed.AbsolutePath)
         );
     }
-    
+
+    private string GetOriginalResolutionPhotoUrl(string url)
+    {
+        var uri = new Uri(url);
+        var query = uri.Query;
+        var queryDictionary = HttpUtility.ParseQueryString(query);
+        if (queryDictionary.AllKeys.Contains("name"))
+        {
+            queryDictionary.Remove("name");
+        }
+        queryDictionary.Add("name", "orig");
+        var builder = new UriBuilder(uri)
+        {
+            Query = queryDictionary.ToString()
+        };
+        return builder.Uri.ToString();
+    }
+
     private ProcessResponse HandlePhoto(FxTwitterTweet tweet, IEnumerable<PhotoResult> results, bool mainTweetHasMedia)
     {
         _logger.LogDebug("Processing as photo embed");
@@ -342,7 +360,7 @@ public sealed class FxTwitter : BaseSite
                         IsInline = true
                     },
                 },
-                ImageUrl = photo.Photo.Url,
+                ImageUrl = this.GetOriginalResolutionPhotoUrl(photo.Photo.Url),
                 Footer = new EmbedFooterBuilder { IconUrl = Constants.TwitterIconUrl, Text = "Twitter" },
             };
             


### PR DESCRIPTION
This updates the twitter embeds to link to high resolution versions of the images. This will NOT affect how large the images displayed in Discord are, as Discord has a process to fetch the images on their end and generate thumbnail/preview images that are lower quality/resolution than the originals. I've tested this locally and the images that Discord generates in the thumbnails/previews are the same size as they currently are in the release version.

The only change is that if a user right clicks the image and selects "save image" within Discord, the high resolution will be saved instead of the lower resolution default image that Twitter serves.