### PR TITLE
Remove matched message

### DIFF
--- a/SaucyBot/Services/SiteManager.cs
+++ b/SaucyBot/Services/SiteManager.cs
@@ -156,8 +156,6 @@ public sealed partial class SiteManager
         foreach (var (site, match) in results)
         {
             _logger.LogDebug("Matched link \"{Match}\" to site {Site}", match, site);
-            
-            var matchedMessage = await SendMatchedMessage(message, site);
 
             try
             {
@@ -166,12 +164,6 @@ public sealed partial class SiteManager
                 if (response is null)
                 {
                     _logger.LogDebug("Failed to process match \"{Match}\" of site {Site}", match, site);
-
-                    if (matchedMessage is not null)
-                    {
-                        await matchedMessage.DeleteAsync();
-                    }
-
                     continue;
                 }
 
@@ -185,13 +177,6 @@ public sealed partial class SiteManager
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Exception occured processing or sending messages");
-            }
-            finally
-            {
-                if (matchedMessage is not null)
-                {
-                    await matchedMessage.DeleteAsync();
-                }
             }
         }
     }
@@ -238,18 +223,6 @@ public sealed partial class SiteManager
                 await command.FollowupAsync("Failed to create embed information for provided URL", ephemeral: true);
             }
         }
-    }
-
-    private async Task<IUserMessage?> SendMatchedMessage(SocketUserMessage message, string site)
-    {
-        var guildConfiguration = await _guildConfigurationManager.GetByChannel(message.Channel);
-
-        if (guildConfiguration is null || !guildConfiguration.SendMatchedMessage)
-        {
-            return null;
-        }
-
-        return await message.ReplyAsync($"Matched link to {site}, please wait...", allowedMentions: AllowedMentions.None);
     }
 
     private static bool ShouldProcessMessage(SocketUserMessage message)


### PR DESCRIPTION
Possible solution to #22 is to just remove the matched message entirely

Reasoning:
1. Not really necessary in the first place. If a message is matched then an embedded message will be posted, so no need to tell the user that one is about to be posted. It either will be or won't be. So the "matched" message doesn't add anything.
2. Notification churn. User gets two notifications for every matched link, but in the end only sees one message. Getting three notifications for each link that gets matched (the original message, matched message, saucybot embed) is more than we really need. 
3. Triggers more API calls than necessary. Instead of just a single call to send the embedded message, we have 3 calls (matched message, embed message, delete matched message).
4. Orphaned matched messages when cleanup doesn't happen. This was the issue presented in #22 
5. Minor, but this also removes a code smell. On the null-response path the code deletes the message inside the `if` and again in the `finally`, so `DeleteAsync` runs twice on the same message. The second call operates on an already-deleted message. Removing this cleans up the code a bit.